### PR TITLE
Remove regex manager for docker_registry_image resources

### DIFF
--- a/modules/docker/outline/outline.tf
+++ b/modules/docker/outline/outline.tf
@@ -1,5 +1,5 @@
 data "docker_registry_image" "outline" {
-  name = "outlinewiki/outline:0.84.0" # renovate: docker
+  name = "outlinewiki/outline:0.84.0"
 }
 
 resource "docker_image" "outline" {

--- a/modules/docker/outline/postgres.tf
+++ b/modules/docker/outline/postgres.tf
@@ -1,5 +1,5 @@
 data "docker_registry_image" "postgres" {
-  name = "postgres:17.5" # renovate: docker
+  name = "postgres:17.5"
 }
 
 resource "docker_image" "postgres" {

--- a/modules/docker/outline/redis.tf
+++ b/modules/docker/outline/redis.tf
@@ -1,5 +1,5 @@
 data "docker_registry_image" "redis" {
-  name = "redis:7.4.3" # renovate: docker
+  name = "redis:7.4.3"
 }
 
 resource "docker_image" "redis" {

--- a/modules/docker/plane/images.tf
+++ b/modules/docker/plane/images.tf
@@ -1,5 +1,5 @@
 data "docker_registry_image" "plane_frontend" {
-  name = "makeplane/plane-frontend:v0.22-dev" # renovate: docker
+  name = "makeplane/plane-frontend:v0.22-dev"
 }
 
 resource "docker_image" "plane_frontend" {
@@ -8,7 +8,7 @@ resource "docker_image" "plane_frontend" {
 }
 
 data "docker_registry_image" "plane_space" {
-  name = "makeplane/plane-space:v0.22-dev" # renovate: docker
+  name = "makeplane/plane-space:v0.22-dev"
 }
 
 resource "docker_image" "plane_space" {
@@ -17,7 +17,7 @@ resource "docker_image" "plane_space" {
 }
 
 data "docker_registry_image" "plane_admin" {
-  name = "makeplane/plane-admin:v0.22-dev" # renovate: docker
+  name = "makeplane/plane-admin:v0.22-dev"
 }
 
 resource "docker_image" "plane_admin" {
@@ -26,7 +26,7 @@ resource "docker_image" "plane_admin" {
 }
 
 data "docker_registry_image" "plane_backend" {
-  name = "makeplane/plane-backend:v0.22-dev" # renovate: docker
+  name = "makeplane/plane-backend:v0.22-dev"
 }
 
 resource "docker_image" "plane_backend" {
@@ -35,7 +35,7 @@ resource "docker_image" "plane_backend" {
 }
 
 data "docker_registry_image" "plane_proxy" {
-  name = "makeplane/plane-proxy:v0.22-dev" # renovate: docker
+  name = "makeplane/plane-proxy:v0.22-dev"
 }
 
 resource "docker_image" "plane_proxy" {
@@ -44,7 +44,7 @@ resource "docker_image" "plane_proxy" {
 }
 
 data "docker_registry_image" "postgres" {
-  name = "postgres:15.7-alpine" # renovate: docker
+  name = "postgres:15.7-alpine"
 }
 
 resource "docker_image" "postgres" {
@@ -53,7 +53,7 @@ resource "docker_image" "postgres" {
 }
 
 data "docker_registry_image" "valkey" {
-  name = "valkey/valkey:7.2.5-alpine" # renovate: docker
+  name = "valkey/valkey:7.2.5-alpine"
 }
 
 resource "docker_image" "valkey" {

--- a/modules/docker/proxy/main.tf
+++ b/modules/docker/proxy/main.tf
@@ -12,7 +12,7 @@ terraform {
 }
 
 data "docker_registry_image" "proxy" {
-  name = "nginxproxy/nginx-proxy:1.7.1" # renovate: docker
+  name = "nginxproxy/nginx-proxy:1.7.1"
 }
 
 resource "docker_image" "proxy" {

--- a/renovate.json
+++ b/renovate.json
@@ -31,18 +31,5 @@
       ],
       "additionalBranchPrefix": "{{parentDir}}-"
     }
-  ],
-  "customManagers": [
-    {
-      "customType": "regex",
-      "fileMatch": [
-        "modules/docker/.+\\.tf$"
-      ],
-      "datasourceTemplate": "docker",
-      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}docker{{/if}}",
-      "matchStrings": [
-        "\"(?<depName>.*?):(?<currentValue>.*?)\" # renovate: docker( versioning=(?<versioning>.*?))?"
-      ]
-    }
   ]
 }


### PR DESCRIPTION
Renovate supports them natively now and therefore we don't need the custom regex manager for that anymore.